### PR TITLE
added --loglevel warn to the npm view command

### DIFF
--- a/lib/pjup.js
+++ b/lib/pjup.js
@@ -38,7 +38,7 @@ function _run(dependencyKey, cbRuns) {
 
         asyncObject[key] = function(cbVersions) {
 
-            sh.exec('npm view ' + key + ' version', {silent:true}, function(code, output) {
+            sh.exec('npm view ' + key + ' version --loglevel warn', {silent:true}, function(code, output) {
 
                 process.stdout.write('.');
 


### PR DESCRIPTION
This fixed the issue with having the loglevel at something besides warn returning more than just the version number from the npm view command.

resolve #2 
